### PR TITLE
Try and force precompilation

### DIFF
--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -27,4 +27,10 @@ function __init__()
     @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" include("forwarddiff.jl")
 end
 
+y = rand(1)
+x = rand(1)
+@batch for i ∈ eachindex(y,x)
+  y[i] = sin(x[i])
+end
+
 end


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, SnoopCompile

function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5()
tinf = @snoopi_deep solve(prob,alg)

Before:
InferenceTimingNode: 2.285476/19.503069 on Core.Compiler.Timings.ROOT() with 54 direct children

After:
InferenceTimingNode: 2.247376/19.289887 on Core.Compiler.Timings.ROOT() with 54 direct children
```

with the TriangularSolve one.