### PR TITLE
Implement two flavors of threaded jacobian with tests

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -52,4 +52,116 @@ function threaded_gradient!(f::F, Δx::AbstractVector, x::AbstractVector, ::Forw
     r[]
 end
 
+#### in-place jac, out-of-place f ####
 
+function evaluate_jacobian_chunks!(f::F, (Δx,x), start, stop, ::ForwardDiff.Chunk{C}) where {F,C}
+    cfg = ForwardDiff.JacobianConfig(f, x, ForwardDiff.Chunk{C}(), nothing)
+
+    # figure out loop bounds
+    N = length(x)
+    last_stop = cld_fast(N, C)
+    is_last = last_stop == stop
+    stop -= is_last
+
+    # seed work arrays
+    xdual = cfg.duals
+    ForwardDiff.seed!(xdual, x)
+    seeds = cfg.seeds
+
+    # handle intermediate chunks
+    for c ∈ start:stop
+        # compute xdual
+        i = (c-1) * C + 1
+        ForwardDiff.seed!(xdual, x, i, seeds)
+        
+        # compute ydual
+        ydual = f(xdual)
+
+        # extract part of the Jacobian
+        Δx_reshaped = ForwardDiff.reshape_jacobian(Δx, ydual, xdual)
+        ForwardDiff.extract_jacobian_chunk!(Nothing, Δx_reshaped, ydual, i, C)
+        ForwardDiff.seed!(xdual, x, i)
+    end
+
+    # handle the last chunk
+    if is_last
+        lastchunksize = C + N - last_stop*C
+        lastchunkindex = N - lastchunksize + 1
+
+        # compute xdual
+        ForwardDiff.seed!(xdual, x, lastchunkindex, seeds, lastchunksize)
+        
+        # compute ydual
+        _ydual = f(xdual)
+        
+        # extract part of the Jacobian
+        _Δx_reshaped = ForwardDiff.reshape_jacobian(Δx, _ydual, xdual)
+        ForwardDiff.extract_jacobian_chunk!(Nothing, _Δx_reshaped, _ydual, lastchunkindex, lastchunksize)
+    end
+end
+
+function threaded_jacobian!(f::F, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
+    N = length(x)
+    d = cld_fast(N, C)
+    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop
+        evaluate_jacobian_chunks!(f, Δxx, start, stop, ForwardDiff.Chunk{C}())
+    end
+    return Δx
+end
+
+# # #### in-place jac, in-place f ####
+
+function evaluate_f_and_jacobian_chunks!(f!::F, (y,Δx,x), start, stop, ::ForwardDiff.Chunk{C}) where {F,C}
+    cfg = ForwardDiff.JacobianConfig(f!, y, x, ForwardDiff.Chunk{C}(), nothing)
+
+    # figure out loop bounds
+    N = length(x)
+    last_stop = cld_fast(N, C)
+    is_last = last_stop == stop
+    stop -= is_last
+
+    # seed work arrays
+    ydual, xdual = cfg.duals
+    ForwardDiff.seed!(xdual, x)
+    seeds = cfg.seeds
+    Δx_reshaped = ForwardDiff.reshape_jacobian(Δx, ydual, xdual)
+
+    # handle intermediate chunks
+    for c ∈ start:stop
+        # compute xdual
+        i = (c-1) * C + 1
+        ForwardDiff.seed!(xdual, x, i, seeds)
+        
+        # compute ydual
+        f!(ForwardDiff.seed!(ydual, y), xdual)
+
+        # extract part of the Jacobian
+        ForwardDiff.extract_jacobian_chunk!(Nothing, Δx_reshaped, ydual, i, C)
+        ForwardDiff.seed!(xdual, x, i)
+    end
+
+    # handle the last chunk
+    if is_last
+        lastchunksize = C + N - last_stop*C
+        lastchunkindex = N - lastchunksize + 1
+
+        # compute xdual
+        ForwardDiff.seed!(xdual, x, lastchunkindex, seeds, lastchunksize)
+        
+        # compute ydual
+        f!(ForwardDiff.seed!(ydual, y), xdual)
+        
+        # extract part of the Jacobian
+        ForwardDiff.extract_jacobian_chunk!(Nothing, Δx_reshaped, ydual, lastchunkindex, lastchunksize)
+        map!(d -> ForwardDiff.value(d), y, ydual)
+    end
+end
+
+function threaded_jacobian!(f!::F, y::AbstractArray, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
+    N = length(x)
+    d = cld_fast(N, C)
+    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop
+        evaluate_f_and_jacobian_chunks!(f!, yΔxx, start, stop, ForwardDiff.Chunk{C}())
+    end
+    Δx
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,23 @@ end
         Polyester.threaded_gradient!(f, view(dx, start%Int:stop%Int), view(x, start%Int:stop%Int), ForwardDiff.Chunk(8))
     end;
     @test dx ≈ dxref
+
+    dxref = similar(x, 100, 800);
+    dx = similar(dxref);
+    yref = similar(x, 100);
+    y = similar(x, 100);
+    A = randn(100, 800)
+    g!(y, x) = (y .= A*x)
+    g(x) = A*x
+
+    Polyester.threaded_jacobian!(g, dx, x, ForwardDiff.Chunk(8));
+    ForwardDiff.jacobian!(dxref, g, x, ForwardDiff.JacobianConfig(g, x, ForwardDiff.Chunk(8), nothing));
+    @test dx ≈ dxref
+
+    Polyester.threaded_jacobian!(g!, y, dx, x, ForwardDiff.Chunk(8));
+    ForwardDiff.jacobian!(dxref, g!, yref, x, ForwardDiff.JacobianConfig(g!, yref, x, ForwardDiff.Chunk(8), nothing));
+    @test dx ≈ dxref
+    @test y ≈ yref
 end
 
 @testset "Non-UnitRange loops" begin


### PR DESCRIPTION
Aside from function names, there are some allocations in the in-place/in-place version that I can't figure out.

A little test script:

```julia
using Revise
using BenchmarkTools, LinearAlgebra, Polyester, ForwardDiff

n = 100
p = 500

function compare_jacobian(n, p)
    A = randn(n, p)
    y = randn(n)
    x = zeros(p)

    function f(x)
        y - A*x
    end

    function f!(r, x)
        copyto!(r, y)
        mul!(r, A, x, -1.0, 1.0)
    end

    Δy = similar(y)
    Δx = similar(A)
    chunk_sizes = (1, 2, 4,#= 8, 16,=#)
    
    println("in-place Jacobian, out-of-place f")
    for (k, C) in enumerate(chunk_sizes)
        chunk = ForwardDiff.Chunk(C)
        cfg = ForwardDiff.JacobianConfig(f, x, chunk)
        println("  Chunk{$C}")
        print("    ⋅ForwardDiff")
        @btime ForwardDiff.jacobian!($Δx, $f, $x, $cfg)
        print("    ⋅Polyester  ")
        @btime Polyester.threaded_jacobian!($f, $Δx, $x, $chunk)
        # println("  Chunk{$C}")
        # print("    ⋅ForwardDiff")
        # @time ForwardDiff.jacobian!(Δx, f, x, cfg)
        # print("    ⋅Polyester  ")
        # @time Polyester.threaded_jacobian!(f, Δx, x, chunk)
    end

    println("in-place Jacobian, in-place f")
    for (k, C) in enumerate(chunk_sizes)
        chunk = ForwardDiff.Chunk(C)
        cfg = ForwardDiff.JacobianConfig(f!, Δy, x, chunk)
        println("  Chunk{$C}")
        print("    ⋅ForwardDiff")
        @btime ForwardDiff.jacobian!($Δx, $f!, $Δy, $x, $cfg)
        print("    ⋅Polyester  ")
        @btime Polyester.threaded_jacobian!($f!, $Δy, $Δx, $x, $chunk)
        # println("  Chunk{$C}")
        # print("    ⋅ForwardDiff")
        # @time ForwardDiff.jacobian!(Δx, f!, Δy, x, cfg)
        # print("    ⋅Polyester  ")
        # @time Polyester.threaded_jacobian!(f!, Δy, Δx, x, chunk)
    end

    return nothing
end
```
Sample output:
```julia
in-place Jacobian, out-of-place f
  Chunk{1}
    ⋅ForwardDiff  11.537 ms (1000 allocations: 1.72 MiB)
    ⋅Polyester    1.495 ms (1010 allocations: 1.79 MiB)
  Chunk{2}
    ⋅ForwardDiff  7.650 ms (500 allocations: 1.22 MiB)
    ⋅Polyester    1.003 ms (510 allocations: 1.31 MiB)
  Chunk{4}
    ⋅ForwardDiff  3.972 ms (250 allocations: 1015.62 KiB)
    ⋅Polyester    531.720 μs (268 allocations: 1.15 MiB)
in-place Jacobian, in-place f
  Chunk{1}
    ⋅ForwardDiff  11.602 ms (0 allocations: 0 bytes)
    ⋅Polyester    2.550 ms (100018 allocations: 1.60 MiB)
  Chunk{2}
    ⋅ForwardDiff  7.572 ms (0 allocations: 0 bytes)
    ⋅Polyester    1.664 ms (100018 allocations: 1.64 MiB)
  Chunk{4}
    ⋅ForwardDiff  3.935 ms (0 allocations: 0 bytes)
    ⋅Polyester    1.172 ms (100026 allocations: 1.71 MiB)
```


```julia
julia> versioninfo()
Julia Version 1.6.3-pre.75
Commit 11e64d1c57 (2021-09-07 14:31 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Core(TM) i9-10900KF CPU @ 3.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
Environment:
  JULIA = ~/julia
```