### PR TITLE
Attempt at a threadlocal storage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polyester"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -30,9 +30,8 @@ julia = "1.5"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "ForwardDiff", "Test"]
+test = ["Aqua", "ForwardDiff", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -30,8 +30,9 @@ julia = "1.5"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ForwardDiff", "Test"]
+test = ["Aqua", "BenchmarkTools", "ForwardDiff", "Test"]

--- a/README.md
+++ b/README.md
@@ -444,5 +444,5 @@ julia> let
            println(threadlocal)
        end
 
-Float16[83.0, 90.0, 27.0, 65.0
+Float16[83.0, 90.0, 27.0, 65.0]
 ```

--- a/README.md
+++ b/README.md
@@ -435,3 +435,14 @@ index 5, thread 3, local storage 51
 index 2, thread 2, local storage 16
 Any[32, 17, 52, 35]
 ```
+
+Optionally, a type can be specified for the thread-local storage:
+```julia
+julia> let
+           @batch threadlocal=rand(10:99)::Float16 for i in 0:9
+           end
+           println(threadlocal)
+       end
+
+Float16[83.0, 90.0, 27.0, 65.0
+```

--- a/README.md
+++ b/README.md
@@ -412,3 +412,26 @@ Note that `@batch` defaults to using up to one thread per physical core, instead
 is because [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl) currently only uses up to 1 thread per physical core, and switching the number of
 threads incurs some overhead. See the docstring on `@batch` (i.e., `?@batch` in a Julia REPL) for some more discussion.
 
+You also can define local storage for each thread, providing a vector containing each of the local storages at the end.
+
+```julia
+julia> let
+           @batch threadlocal=rand(10:99) for i in 0:9
+               println("index $i, thread $(Threads.threadid()), local storage $threadlocal")
+               threadlocal += 1
+           end
+           println(threadlocal)
+       end
+
+index 8, thread 1, local storage 30
+index 3, thread 3, local storage 49
+index 9, thread 1, local storage 31
+index 6, thread 4, local storage 33
+index 0, thread 2, local storage 14
+index 4, thread 3, local storage 50
+index 7, thread 4, local storage 34
+index 1, thread 2, local storage 15
+index 5, thread 3, local storage 51
+index 2, thread 2, local storage 16
+Any[32, 17, 52, 35]
+```

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -1,21 +1,32 @@
-struct BatchClosure{F, A, B}
+struct BatchClosure{F, A, B, C} # B is a Val{Bool} triggering free_local_threads!; C is a Val{Bool} triggering local storage
   f::F
 end
-function (b::BatchClosure{F,A,B})(p::Ptr{UInt}) where {F,A,B}
+function (b::BatchClosure{F,A,B,C})(p::Ptr{UInt}) where {F,A,B,C}
   (offset, args) = ThreadingUtilities.load(p, A, 2*sizeof(UInt))
   (offset, start) = ThreadingUtilities.load(p, UInt, offset)
   (offset, stop ) = ThreadingUtilities.load(p, UInt, offset)
-  (offset, i ) = ThreadingUtilities.load(p, UInt, offset)
-  b.f(args, (start+one(UInt))%Int, stop%Int, i%Int)
+  if C
+    ((offset, i ) = ThreadingUtilities.load(p, UInt, offset))
+    b.f(args, (start+one(UInt))%Int, stop%Int, i%Int)
+  else
+    b.f(args, (start+one(UInt))%Int, stop%Int)
+  end
   # B && free_local_threads!()
   nothing
 end
 
-@inline function batch_closure(f::F, args::A, ::Val{B}) where {F,A,B}
-  bc = BatchClosure{F,A,B}(f)
+@inline function batch_closure(f::F, args::A, ::Val{B}, ::Val{C}) where {F,A,B, C}
+  bc = BatchClosure{F,A,B,C}(f)
   @cfunction($bc, Cvoid, (Ptr{UInt},))
 end
 
+@inline function setup_batch!(p::Ptr{UInt}, fptr::Ptr{Cvoid}, argtup, start::UInt, stop::UInt)
+  offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
+  offset = ThreadingUtilities.store!(p, argtup, offset)
+  offset = ThreadingUtilities.store!(p, start, offset)
+  offset = ThreadingUtilities.store!(p, stop, offset)
+  nothing
+end
 @inline function setup_batch!(p::Ptr{UInt}, fptr::Ptr{Cvoid}, argtup, start::UInt, stop::UInt, i::UInt)
   offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
   offset = ThreadingUtilities.store!(p, argtup, offset)
@@ -23,6 +34,12 @@ end
   offset = ThreadingUtilities.store!(p, stop, offset)
   offset = ThreadingUtilities.store!(p, i, offset)
   nothing
+end
+@inline function launch_batched_thread!(cfunc, tid, argtup, start, stop)
+  fptr = Base.unsafe_convert(Ptr{Cvoid}, cfunc)
+  ThreadingUtilities.launch(tid, fptr, argtup, start, stop) do p, fptr, argtup, start, stop
+    setup_batch!(p, fptr, argtup, start, stop)
+  end
 end
 @inline function launch_batched_thread!(cfunc, tid, argtup, start, stop, i)
   fptr = Base.unsafe_convert(Ptr{Cvoid}, cfunc)
@@ -52,7 +69,7 @@ function add_var!(q, argtup, gcpres, ::Type{T}, argtupname, gcpresname, k) where
   end
 end
 @generated function _batch_no_reserve(
-  f!::F, threadmask_tuple::NTuple{N}, nthread_tuple, torelease_tuple, Nr, Nd, ulen, args::Vararg{Any,K}
+  f!::F, threadmask_tuple::NTuple{N}, nthread_tuple, torelease_tuple, Nr, Nd, ulen, args::Vararg{Any,K}; threadlocal::Bool=false
 ) where {F,K,N}
   q = quote
     $(Expr(:meta,:inline))
@@ -75,12 +92,20 @@ end
         tz += 0x00000001
         tid += tz
         tm >>>= tz
-        launch_batched_thread!(cfunc, tid, argtup, start, stop, i%UInt)
+        if threadlocal
+          launch_batched_thread!(cfunc, tid, argtup, start, stop, i%UInt)
+        else
+          launch_batched_thread!(cfunc, tid, argtup, start, stop)
+        end  
         start = stop
       end
       Nr -= nthread
     end
-    f!(arguments, (start+one(UInt)) % Int, ulen % Int, (sum(nthread_tuple)+1)%Int)
+    if threadlocal
+        f!(arguments, (start+one(UInt)) % Int, ulen % Int, (sum(nthread_tuple)+1)%Int)
+    else
+        f!(arguments, (start+one(UInt)) % Int, ulen % Int)
+    end
     for (threadmask, nthread, torelease) ∈ zip(threadmask_tuple, nthread_tuple, torelease_tuple)
       tm = mask(UnsignedIteratorEarlyStop(threadmask, nthread))
       tid = 0x00000000
@@ -102,7 +127,7 @@ end
   for k ∈ 1:K
     add_var!(q, argt, gcpr, args[k], :args, :gcp, k)
   end
-  push!(q.args, :(arguments = $argt), :(argtup = Reference(arguments)), :(cfunc = batch_closure(f!, argtup, Val{false}())), gcpr)
+  push!(q.args, :(arguments = $argt), :(argtup = Reference(arguments)), :(cfunc = batch_closure(f!, argtup, Val{false}(), Val{threadlocal}())), gcpr)
   push!(q.args, nothing)
   q
 end
@@ -202,7 +227,7 @@ end
 
 
 @inline function batch(
-  f!::F, (len, nbatches)::Tuple{Vararg{Integer,2}}, args::Vararg{Any,K}
+  f!::F, (len, nbatches)::Tuple{Vararg{Integer,2}}, args::Vararg{Any,K}; threadlocal::Bool=false
 ) where {F,K}
   # threads, torelease = request_threads(Base.Threads.threadid(), nbatches - one(nbatches))
   threads, torelease = request_threads(nbatches - one(nbatches))
@@ -210,19 +235,23 @@ end
   nthread = sum(nthreads)
   ulen = len % UInt
   if nthread % Int32 ≤ zero(Int32)
-    f!(args, one(Int), ulen % Int, 1)
+    if threadlocal
+      f!(args, one(Int), ulen % Int, 1)
+    else
+      f!(args, one(Int), ulen % Int)
+    end
     return
   end
   nbatch = nthread + one(nthread)
   Nd = Base.udiv_int(ulen, nbatch % UInt) # reasonable for `ulen` to be ≥ 2^32
   Nr = ulen - Nd * nbatch
 
-  _batch_no_reserve(f!, map(mask,threads), nthreads, torelease, Nr, Nd, ulen, args...)
+  _batch_no_reserve(f!, map(mask,threads), nthreads, torelease, Nr, Nd, ulen, args...; threadlocal=threadlocal)
 end
 function batch(
-  f!::F, (len, nbatches, reserve_per_worker)::Tuple{Vararg{Integer,3}}, args::Vararg{Any,K}
+  f!::F, (len, nbatches, reserve_per_worker)::Tuple{Vararg{Integer,3}}, args::Vararg{Any,K}; threadlocal::Bool=false
 ) where {F,K}
-  batch(f!, (len, nbatches), args...)
+  batch(f!, (len, nbatches), args...; threadlocal=false)
   # ulen = len % UInt
   # if nbatches > 1
   #   requested_threads = reserve_per_worker*nbatches

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -298,13 +298,13 @@ function enclose(exorig::Expr, reserve_per, minbatchsize, per::Symbol, threadloc
       $(esc(threadlocal_var))[i] = $(esc(threadlocal))
     end
   end 
-  threadlocal_get           = threadlocal == :() ? :() : :( $threadlocal_var_gen = $threadlocal_var[Threads.threadid()] )
-  threadlocal_set           = threadlocal == :() ? :() : :( $threadlocal_var[Threads.threadid()] = $threadlocal_var_gen )
+  threadlocal_get           = threadlocal == :() ? :() : :( $threadlocal_var_gen = $threadlocal_var[var"##THREAD##"] )
+  threadlocal_set           = threadlocal == :() ? :() : :( $threadlocal_var[var"##THREAD##"] = $threadlocal_var_gen )
   push!(q.args, threadlocal_init2)
   args = Expr(:tuple, Symbol("##LOOPOFFSET##"), Symbol("##LOOP_STEP##"))
   closureq = quote
     $closure = let
-      @inline ($args, var"##SUBSTART##"::Int, var"##SUBSTOP##"::Int) -> begin
+      @inline ($args, var"##SUBSTART##"::Int, var"##SUBSTOP##"::Int, var"##THREAD##"::Int) -> begin
         var"##LOOPSTART##" = var"##SUBSTART##" * var"##LOOP_STEP##" + var"##LOOPOFFSET##" - var"##LOOP_STEP##"
         var"##LOOP_STOP##" = var"##SUBSTOP##" * var"##LOOP_STEP##" + var"##LOOPOFFSET##" - var"##LOOP_STEP##"
         $threadlocal_get

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -381,6 +381,6 @@ end
 macro batch(arg1, arg2, arg3, ex)
   reserve, minbatch, per = interpret_kwarg(arg1)
   reserve, minbatch, per = interpret_kwarg(arg2, reserve, minbatch, per)
-  reserve, minbatch, per = interpret_kwarg(arg2, reserve, minbatch, per)
+  reserve, minbatch, per = interpret_kwarg(arg3, reserve, minbatch, per)
   enclose(macroexpand(__module__, ex), reserve, minbatch, per, __module__)
 end

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -371,7 +371,7 @@ You can pass both `per=(core/thread)` and `minbatch=N` options at the same time,
     @batch minbatch=5000 per=core   for i in Iter; ...; end
 """
 macro batch(ex)
-  enclose(macroexpand(__module__, ex), 0, 1, :core, __module__)
+  enclose(macroexpand(__module__, ex), 0, 1, :core, :(), __module__)
 end
 function interpret_kwarg(arg, reserve_per = 0, minbatch = 1, per = :core, threadlocal = :())
   a = arg.args[1]

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -346,6 +346,15 @@ Evaluate the loop on multiple threads.
 
     @batch minbatch=N for i in Iter; ...; end
 
+Create a thread-local storage used in the loop.
+
+    @batch localthread=init() for i in Iter; ...; end
+
+The `init` function will be called at the start at each thread.
+`localthread` will refer to storage local for the thread.
+At the end of the loop, a `localthread` vector containing all the thread-local values
+will be available.
+
 Evaluate at least N iterations per thread. Will use at most `length(Iter) ÷ N` threads.
 
     @batch per=core for i in Iter; ...; end

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -292,13 +292,8 @@ function enclose(exorig::Expr, reserve_per, minbatchsize, per::Symbol, threadloc
   threadlocal_init_single   = threadlocal == :() ? :() : :( $threadlocal_var = $threadlocal )
   threadlocal_repack_single = threadlocal == :() ? :() : :( threadlocal = $threadlocal_type[threadlocal] )
   threadlocal_init1         = threadlocal == :() ? :() : :( $threadlocal_var = Vector{$threadlocal_type}(undef, 0) )
-  threadlocal_init2         = threadlocal == :() ? :() : quote
-    resize!($(esc(threadlocal_var)),max(1,$(threadtup.args[2]))) # Why is the max necessary?
-    for i in eachindex($(esc(threadlocal_var)))
-      $(esc(threadlocal_var))[i] = $(esc(threadlocal))
-    end
-  end 
-  threadlocal_get           = threadlocal == :() ? :() : :( $threadlocal_var_gen = $threadlocal_var[var"##THREAD##"] )
+  threadlocal_init2         = threadlocal == :() ? :() : :( resize!($(esc(threadlocal_var)),max(1,$(threadtup.args[2]))) )
+  threadlocal_get           = threadlocal == :() ? :() : :( $threadlocal_var_gen = $threadlocal::$threadlocal_type )
   threadlocal_set           = threadlocal == :() ? :() : :( $threadlocal_var[var"##THREAD##"] = $threadlocal_var_gen )
   push!(q.args, threadlocal_init2)
   args = Expr(:tuple, Symbol("##LOOPOFFSET##"), Symbol("##LOOP_STEP##"))

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -46,7 +46,7 @@ function threaded_gradient!(f::F, Δx::AbstractVector, x::AbstractVector, ::Forw
     N = length(x)
     d = cld_fast(N, C)
     r = Ref{eltype(Δx)}()
-    batch((d,min(d,num_threads())), r, Δx, x) do rΔxx,start,stop
+    batch((d,min(d,num_threads())), r, Δx, x) do rΔxx,start,stop,ti
         evaluate_chunks!(f, rΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     r[]
@@ -103,7 +103,7 @@ end
 function threaded_jacobian!(f::F, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop
+    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop,ti
         evaluate_jacobian_chunks!(f, Δxx, start, stop, ForwardDiff.Chunk{C}())
     end
     return Δx
@@ -160,7 +160,7 @@ end
 function threaded_jacobian!(f!::F, y::AbstractArray, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop
+    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop,ti
         evaluate_f_and_jacobian_chunks!(f!, yΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     Δx

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -46,7 +46,7 @@ function threaded_gradient!(f::F, Δx::AbstractVector, x::AbstractVector, ::Forw
     N = length(x)
     d = cld_fast(N, C)
     r = Ref{eltype(Δx)}()
-    batch((d,min(d,num_threads())), r, Δx, x) do rΔxx,start,stop,ti
+    batch((d,min(d,num_threads())), r, Δx, x) do rΔxx,start,stop
         evaluate_chunks!(f, rΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     r[]
@@ -103,7 +103,7 @@ end
 function threaded_jacobian!(f::F, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop,ti
+    batch((d,min(d,num_threads())), Δx, x) do Δxx,start,stop
         evaluate_jacobian_chunks!(f, Δxx, start, stop, ForwardDiff.Chunk{C}())
     end
     return Δx
@@ -160,7 +160,7 @@ end
 function threaded_jacobian!(f!::F, y::AbstractArray, Δx::AbstractArray, x::AbstractArray, ::ForwardDiff.Chunk{C}) where {F,C}
     N = length(x)
     d = cld_fast(N, C)
-    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop,ti
+    batch((d,min(d,num_threads())), y, Δx, x) do yΔxx,start,stop
         evaluate_f_and_jacobian_chunks!(f!, yΔxx, start, stop, ForwardDiff.Chunk{C}())
     end
     Δx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -350,6 +350,14 @@ end
     threadlocal
   end
   @test length(inits)==1 || inits[1]!=inits[2]
+  # check that types are respected
+  settingtype = let
+    @batch threadlocal=myinitA()::Float16 for i in 0:9
+        threadlocal += 1
+    end
+    threadlocal
+  end
+  @test eltype(settingtype)==Float16
 end
 
 if VERSION ≥ v"1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,7 +55,7 @@ end
 function tmap!(f::F, args::Vararg{AbstractArray,K}) where {K,F}
     dest = first(args)
     N = length(dest)
-    mapfun! = (allargs, start, stop) -> rangemap!(f, allargs, start, stop)
+    mapfun! = (allargs, start, stop, ti) -> rangemap!(f, allargs, start, stop)
     batch(mapfun!, (N, num_threads()), args...)
     dest
 end
@@ -104,7 +104,7 @@ end
     println("Running `tmap!` test...")
     @test tmap!(foo, z, x, y) ≈ foo.(x, y)
 
-    function slow_task!((x, digits, n), j, k)
+    function slow_task!((x, digits, n), j, k, ti)
         start = 1 + (n * (j - 1)) ÷ num_threads()
         stop =  (n* k) ÷ num_threads()
         target = 0.0
@@ -163,7 +163,7 @@ end
 
 @testset "start and stop values" begin
     println("Running start and stop values tests...")
-    function record_start_stop!((start_indices, end_indices), start, stop)
+    function record_start_stop!((start_indices, end_indices), start, stop, ti)
       start_indices[Threads.threadid()] = start
       end_indices[Threads.threadid()] = stop
       sleep(1) # if task completes two quickly, the mainthread will start stealing work back.
@@ -193,7 +193,7 @@ end
     end
     vec_length = 20
     ts = TestStruct(["init" for i in 1:vec_length])
-    update_text!((ts, val), start, stop) = ts.vec[start:stop] .= val
+    update_text!((ts, val), start, stop, ti) = ts.vec[start:stop] .= val
     batch(update_text!, (vec_length, num_threads()), ts, "new_val")
     @test all(ts.vec .== "new_val")
 
@@ -226,7 +226,7 @@ end
     @test dx == dxref
 
     dx .= NaN;
-    batch((length(x), max(1,num_threads()>>1), 2), dx, x) do (dx,x), start, stop
+    batch((length(x), max(1,num_threads()>>1), 2), dx, x) do (dx,x), start, stop, ti
         Polyester.threaded_gradient!(f, view(dx, start%Int:stop%Int), view(x, start%Int:stop%Int), ForwardDiff.Chunk(8))
     end;
     @test dx ≈ dxref

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,13 +351,21 @@ end
   end
   @test length(inits)==1 || inits[1]!=inits[2]
   # check that types are respected
+  myinitD() = Float16(1.0)
   settingtype = let
-    @batch threadlocal=myinitA()::Float16 for i in 0:9
+    @batch threadlocal=myinitD()::Float16 for i in 0:9
         threadlocal += 1
     end
     threadlocal
   end
   @test eltype(settingtype)==Float16
+  settingabstype = let
+    @batch threadlocal=myinitD()::AbstractFloat for i in 0:9
+        threadlocal += 1
+    end
+    threadlocal
+  end
+  @test eltype(settingabstype)<:AbstractFloat
 end
 
 if VERSION ≥ v"1.6"


### PR DESCRIPTION
Should be as simple as 

```julia
@batch threadlocal=(localvar=ones(5)) for i in 1:10
    f!(localvar)
end
# and here one will have access to `localvar` array containing all the `localvar`s
```

I got stuck at figuring out what the current thread id is inside the closure. Help would be welcomed :)

Warning: I barely understand macros and hygiene.

The first commit is an unrelated typo/bug I think I found.

Related to https://github.com/JuliaSIMD/Polyester.jl/issues/53