### PR TITLE
Fix 64+ threads support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polyester"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.6.14"
+version = "0.6.15"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -21,7 +21,7 @@ BitTwiddlingConvenienceFunctions = "0.1"
 CPUSummary = "0.1.2 - 0.1.8, 0.1.11"
 IfElse = "0.1"
 ManualMemory = "0.1.3"
-PolyesterWeave = "0.1.7"
+PolyesterWeave = "0.1.8"
 Requires = "1"
 Static = "0.7"
 StrideArraysCore = "0.3.11"

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -153,11 +153,10 @@ end
         $launch_quote
         start = stop
       end
-      Nr -= nthread
+      Nr = (Nr - nthread) % Int
     end
     $rem_quote
-    for (threadmask, nthread, torelease) ∈
-        zip(threadmask_tuple, nthread_tuple, torelease_tuple)
+    for (threadmask, nthread) ∈ zip(threadmask_tuple, nthread_tuple)
       tm = mask(UnsignedIteratorEarlyStop(threadmask, nthread))
       tid = 0x00000000
       while tm ≠ zero(tm)
@@ -169,8 +168,8 @@ end
         # @show tid, ThreadingUtilities._atomic_state(tid)
         ThreadingUtilities.wait(tid)
       end
-      free_threads!(torelease)
     end
+    free_threads!(torelease_tuple)
     nothing
   end
   gcpr = Expr(:gc_preserve, block, :cfunc)
@@ -314,7 +313,7 @@ end
   end
   nbatch = nthread + one(nthread)
   Nd = Base.udiv_int(ulen, nbatch % UInt) # reasonable for `ulen` to be ≥ 2^32
-  Nr = ulen - Nd * nbatch
+  Nr = (ulen - Nd * nbatch) % Int
   _batch_no_reserve(
     f!,
     threadlocal,


### PR DESCRIPTION
in conjunction with [this PR](https://github.com/JuliaSIMD/PolyesterWeave.jl/pull/5), this fixes the problems mentioned in #83.

However, from the simple tests I did, those fixes are not enough. Some results on a AMD EPYC 7763 (2x64 cores):

- rarely, iterations are dropped
- sometimes, sigsegv is raised at (I believe) compilation, the stacktraces seems random (when there is one). I have no idea why this can happen
- sometimes `@batch` reliably works

This seems to be some issue with compilation or initialization, since in Julia sessions where the problems don't occur, they seem to never appear.

Here is my testing code (ran with `julia -t 128`):

```julia
julia> using Polyester

julia> tids = zeros(Int, Threads.nthreads());

julia> @batch per=thread for i in 1:Threads.nthreads()
           tids[Threads.threadid()] += 1
       end

julia> all(tids .== 1)
true
```
