### PR TITLE
Remove CPUSummary dependence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polyester"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -9,11 +9,11 @@ using Static
 using Requires
 using PolyesterWeave:
   request_threads, free_threads!, mask, UnsignedIteratorEarlyStop, assume,
-  disable_polyester_threads
-using CPUSummary: num_threads, num_cores
+  disable_polyester_threads,
+  num_threads # used to be taken from CPUSummary, but it caused significant TTFX | TODO remove on next breaking release and consider removing num_cores
+using CPUSummary: num_cores
 
 export batch, @batch, num_threads, disable_polyester_threads
-
 
 include("batch.jl")
 include("closure.jl")


### PR DESCRIPTION
Depends on https://github.com/JuliaSIMD/PolyesterWeave.jl/pull/7

A non-static stub to replace `CPUSummary.num_threads` is made. The reason we are using a stub instead of outright removing `num_threads` is that `Polyester` exports that symbol. We could consider a breaking release which would be a bit cleaner (no stub necessary, directly switching to `Threads.nthreads`).

This would fix https://github.com/JuliaSIMD/Polyester.jl/issues/95 