### PR TITLE
use `dynamic_thread_count` in validation tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     timeout-minutes: 10
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - cputhreads=${{ matrix.juliacputhreads }} juliathreads=${{ matrix.juliathreads }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,11 +15,14 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-        threads:
-          - '3'
         arch:
           - x86
           - x64
+        juliacputhreads:
+          - 3
+        juliathreads:
+          - 2
+          - 4
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -39,8 +42,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: ${{ matrix.threads }}
-          JULIA_CPU_THREADS: ${{ matrix.threads }}
+          JULIA_NUM_THREADS: ${{ matrix.juliathreads }}
+          JULIA_CPU_THREADS: ${{ matrix.juliacputhreads }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,10 @@ jobs:
           - x86
           - x64
         juliacputhreads:
+          - 1
           - 3
         juliathreads:
+          - 1
           - 2
           - 4
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polyester"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.6.19"
+version = "0.6.20"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
One particular test used to fail in cases where `Sys.CPU_THREADS < Threads.nthreads()`. I believe it was an issue with the test, not an issue with the library. This hopefully fixes it. It also adds `Sys.CPU_THREADS < Threads.nthreads()` configurations to the CI.

This should be enough to make https://github.com/JuliaSIMD/PolyesterWeave.jl/pull/12 work.