### PR TITLE
Fix `threadlocal` type-inferrability and add `reduction` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 
 ### Local per-thread storage (`threadlocal`)
 
-**Warning: this feature is likely broken!**
-
 You also can define local storage for each thread, providing a vector containing each of the local storages at the end.
 
 ```julia
@@ -232,6 +230,23 @@ julia> let
        end
 
 Float16[83.0, 90.0, 27.0, 65.0]
+```
+
+## `reduction`
+The `reduction` keyword enables reduction of an already initialized `isbits` variable with certain supported associative operations (see [docs](https://JuliaSIMD.github.io/Polyester.jl/stable)), such that the transition from serialized code is as simple as adding the `@batch` macro.
+
+```julia
+julia> let
+           y1 = 0
+           y2 = 1
+           @batch reduction=((+, y1), (*, y2)) for i in 1:9
+               y1 += i
+               y2 *= i
+           end
+           println(y1, y2)
+       end
+
+45, 362880
 ```
 
 ## Disabling Polyester threads

--- a/README.md
+++ b/README.md
@@ -233,20 +233,22 @@ Float16[83.0, 90.0, 27.0, 65.0]
 ```
 
 ### `reduction`
-The `reduction` keyword enables reduction of an already initialized `isbits` variable with certain supported associative operations (see [docs](https://JuliaSIMD.github.io/Polyester.jl/stable)), such that the transition from serialized code is as simple as adding the `@batch` macro.
+The `reduction` keyword enables reduction of an already initialized `isbits` variable with certain supported associative operations (see [docs](https://JuliaSIMD.github.io/Polyester.jl/stable)), such that the transition from serialized code is as simple as adding the `@batch` macro. Contrary to `threadlocal` this does not incur any additional allocations
 
 ```julia
-julia> let
+julia> function batch_reduction()
            y1 = 0
            y2 = 1
            @batch reduction=((+, y1), (*, y2)) for i in 1:9
                y1 += i
                y2 *= i
            end
-           println(y1, y2)
+           y1, y2
        end
-
-45, 362880
+julia> batch_reduction()
+(45, 362880)
+julia> @allocated batch_reduction()
+0
 ```
 
 ## Disabling Polyester threads

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ julia> let
 Float16[83.0, 90.0, 27.0, 65.0]
 ```
 
-## `reduction`
+### `reduction`
 The `reduction` keyword enables reduction of an already initialized `isbits` variable with certain supported associative operations (see [docs](https://JuliaSIMD.github.io/Polyester.jl/stable)), such that the transition from serialized code is as simple as adding the `@batch` macro.
 
 ```julia

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -8,7 +8,7 @@ import StaticArrayInterface
 const ArrayInterface = StaticArrayInterface
 using Base.Cartesian: @nexprs
 using StaticArrayInterface: static_length, static_step, static_first, static_size
-using StrideArraysCore: StrideArray, object_and_preserve
+using StrideArraysCore: object_and_preserve
 using ManualMemory: Reference
 using Static
 using Requires

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -6,8 +6,9 @@ end
 using ThreadingUtilities
 import StaticArrayInterface
 const ArrayInterface = StaticArrayInterface
+using Base.Cartesian: @nexprs
 using StaticArrayInterface: static_length, static_step, static_first, static_size
-using StrideArraysCore: object_and_preserve
+using StrideArraysCore: StrideArray, object_and_preserve
 using ManualMemory: Reference
 using Static
 using Requires
@@ -19,9 +20,20 @@ using PolyesterWeave:
   UnsignedIteratorEarlyStop,
   assume,
   disable_polyester_threads
-using CPUSummary: num_cores
+using CPUSummary: cache_linesize, num_cores, sys_threads
 
 export batch, @batch, disable_polyester_threads
+
+const SUPPORTED_REDUCE_OPS = (:+, :*, :min, :max, :&, :|)
+initializer(::typeof(+), ::T) where {T} = zero(T)
+initializer(::typeof(+), ::Bool) = zero(Int)
+initializer(::typeof(-), ::T) where {T} = zero(T)
+initializer(::typeof(-), ::Bool) = zero(Int)
+initializer(::typeof(*), ::T) where {T} = one(T)
+initializer(::typeof(min), ::T) where {T} = typemax(T)
+initializer(::typeof(max), ::T) where {T} = typemin(T)
+initializer(::typeof(&), ::Bool) = true
+initializer(::typeof(|), ::Bool) = false
 
 include("batch.jl")
 include("closure.jl")
@@ -38,10 +50,4 @@ function reset_threads!()
   foreach(ThreadingUtilities.checktask, eachindex(ThreadingUtilities.TASKS))
   return nothing
 end
-
-# y = rand(1)
-# x = rand(1)
-# @batch for i ∈ eachindex(y,x)
-#   y[i] = sin(x[i])
-# end
 end

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -20,15 +20,13 @@ using PolyesterWeave:
   UnsignedIteratorEarlyStop,
   assume,
   disable_polyester_threads
-using CPUSummary: cache_linesize, num_cores, sys_threads
+using CPUSummary: num_cores
 
 export batch, @batch, disable_polyester_threads
 
 const SUPPORTED_REDUCE_OPS = (:+, :*, :min, :max, :&, :|)
 initializer(::typeof(+), ::T) where {T} = zero(T)
 initializer(::typeof(+), ::Bool) = zero(Int)
-initializer(::typeof(-), ::T) where {T} = zero(T)
-initializer(::typeof(-), ::Bool) = zero(Int)
 initializer(::typeof(*), ::T) where {T} = one(T)
 initializer(::typeof(min), ::T) where {T} = typemax(T)
 initializer(::typeof(max), ::T) where {T} = typemin(T)

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -193,9 +193,9 @@ end
   )
   launch_quote = if S
     if C === 0
-      :(launch_batched_thread!(cfunc, tid, argtup, start, stop, i % UInt))
+      :(launch_batched_thread!(cfunc, tid, argtup, start, stop, tid % UInt))
     else
-      :(launch_batched_thread!(cfunc, tid, argtup, start, stop, i % UInt, reducinits))
+      :(launch_batched_thread!(cfunc, tid, argtup, start, stop, tid % UInt, reducinits))
     end
   else
     if C === 0

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -351,8 +351,9 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
   return_quote = Expr(:return)
   # threadlocal stuff
   threadlocal_var_single = gensym(threadlocal_var)
-  q_single = symbolsubs(exorig, threadlocal_var, threadlocal_var_single)
   threadlocal_val, threadlocal_type = threadlocal
+  q_single = threadlocal_val === Symbol("") ? exorig :
+    symbolsubs(exorig, threadlocal_var, threadlocal_var_single)
   # threadlocal_type = getfield(mod, threadlocal_type)
   threadlocal_accum = Symbol("##THREADLOCAL##ACCUM##")
   threadlocal_init_single =

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -527,9 +527,11 @@ Perform OpenMP-esque reduction on the `isbits` variables `var1`, `var2`, `...` u
 operations `op1`, `op2`, `...` . The variables have to be initialized before the loop and
 cannot be a fieldname like `x.y` or `x[i]`.
 Supported operations are `+`, `*`, `min`, `max`, `&`, and `|`. The type does not have
-to be provided, since it is already inferred from the initialized variables.
+to be provided, since it is already inferred from the initialized variables---caution has
+to be taken to ensure that the type remains consistent throughout the loop.
 While `threadlocal` can do the same thing, `reduction` does not incur additional allocations
-and is generally more efficient for its purpose.
+and is generally more efficient for its purpose. It is up to the user to ensure that there
+are no data dependencies between iterations, which could lead to incorrect results.
 
     @batch per=core for i in Iter; ...; end
     @batch per=thread for i in Iter; ...; end

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -528,8 +528,8 @@ Perform OpenMP-esque reduction on the `isbits` variables `var1`, `var2`, `...` u
 operations `op1`, `op2`, `...` . The variables have to be initialized before the loop and
 cannot be a fieldname like `x.y` or `x[i]`.
 Supported operations are `+`, `*`, `min`, `max`, `&`, and `|`. The type does not have
-to be provided, since it is already inferred from the initialized variables---caution has
-to be taken to ensure that the type remains consistent throughout the loop.
+to be provided, since it is already inferred from the initialized variables---**caution has
+to be taken to ensure that the type remains consistent throughout the loop**.
 While `threadlocal` can do the same thing, `reduction` does not incur additional allocations
 and is generally more efficient for its purpose. It is up to the user to ensure that there
 are no data dependencies between iterations, which could lead to incorrect results.

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -225,7 +225,7 @@ function makestatic!(expr)
   end
   expr
 end
-function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, stride, mod)
+function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride, mod)
   Meta.isexpr(exorig, :for, 2) ||
     throw(ArgumentError("Expression invalid; should be a for loop."))
   ex = copy(exorig)
@@ -237,6 +237,7 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
   loop_offs = Symbol("##LOOPOFFSET##")
   innerloop = Symbol("##inner##loop##")
   rcombiner = Symbol("##split##recombined##")
+  reduction_op, reduction_var = reduction
   threadlocal_var = Symbol("threadlocal")
   #FIXME: don't do this?
   per = stride ? :thread : per
@@ -244,6 +245,12 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
   arguments = Symbol[innerloop, rcombiner]#loop_offs, loop_step]
   defined = Dict{Symbol,Symbol}(loop_offs => loop_offs, loop_step => loop_step)
   threadlocal_var_gen = getgensym!(defined, threadlocal_var)
+  reduction_var_gen = Expr(:tuple)
+  if reduction_var !== Tuple{}()
+    for i ∈ eachindex(reduction_var)
+      push!(reduction_var_gen.args, getgensym!(defined, reduction_var[i]))
+    end
+  end
   define_induction_variables!(arguments, defined, ex, mod)
   firstloop = ex.args[1]
   if firstloop.head === :block
@@ -340,39 +347,70 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
     push!(threadtup.args, :(min($il, $num_thread_expr)))
   end
   closure = Symbol("##closure##")
-  threadlocal, threadlocal_type = threadlocal_tuple
+  donothing = Expr(:block)
+  return_quote = Expr(:return)
+  # threadlocal stuff
   threadlocal_var_single = gensym(threadlocal_var)
   q_single = symbolsubs(exorig, threadlocal_var, threadlocal_var_single)
-  donothing = Expr(:block)
+  threadlocal_val, threadlocal_type = threadlocal
+  # threadlocal_type = getfield(mod, threadlocal_type)
+  threadlocal_accum = Symbol("##THREADLOCAL##ACCUM##")
   threadlocal_init_single =
-    threadlocal === Symbol("") ? donothing : :($threadlocal_var_single = $threadlocal)
-  threadlocal_repack_single =
-    threadlocal === Symbol("") ? donothing : :($threadlocal_var_single)
-  threadlocal_single_store =
-    threadlocal === Symbol("") ? donothing :
+    threadlocal_val === Symbol("") ? donothing :
+    :($threadlocal_var_single = $threadlocal_val)
+  threadlocal_return_single =
+    threadlocal_val === Symbol("") ? donothing : :($threadlocal_var_single)
+  threadlocal_vect_single =
+    threadlocal_val === Symbol("") ? donothing :
     :($(esc(threadlocal_var)) = [single_thread_result])
-  threadlocal_init1 =
-    threadlocal === Symbol("") ? donothing :
-    :($threadlocal_var = Vector{$threadlocal_type}(undef, 0))
-  threadlocal_init2 =
-    threadlocal === Symbol("") ? donothing :
-    :(resize!($(esc(threadlocal_var)), max(1, $(threadtup.args[2]))))
-  threadlocal_get =
-    threadlocal === Symbol("") ? donothing :
-    :($threadlocal_var_gen = $threadlocal::$threadlocal_type)
-  threadlocal_set =
-    threadlocal === Symbol("") ? donothing :
-    :($threadlocal_var[var"##THREAD##"] = $threadlocal_var_gen)
-  push!(q.args, threadlocal_init2)
-  args = Expr(:tuple, Symbol("##LOOPOFFSET##"), Symbol("##LOOP_STEP##"))
-  closure_args = if threadlocal !== Symbol("") || stride
-    :($args, var"##SUBSTART##"::Int, var"##SUBSTOP##"::Int, var"##THREAD##"::Int)
-  else
-    :($args, var"##SUBSTART##"::Int, var"##SUBSTOP##"::Int)
+  threadlocal_init =
+    threadlocal_val === Symbol("") ? donothing : quote
+    $(esc(threadlocal_accum)) =
+      Vector{$threadlocal_type}(undef, max(1, $(threadtup.args[2])))
   end
+  threadlocal_vect =
+    threadlocal_val === Symbol("") ? donothing :
+    :($(esc(threadlocal_var)) = multi_thread_result)
+  threadlocal_get =
+    threadlocal_val === Symbol("") ? donothing :
+    :($threadlocal_var_gen = $threadlocal_val::$threadlocal_type)
+  threadlocal_set =
+    threadlocal_val === Symbol("") ? donothing :
+    :($threadlocal_accum[var"##THREAD##"] = $threadlocal_var_gen)
+  threadlocal_return =
+    threadlocal_val === Symbol("") ? donothing : :($threadlocal_accum)
+  threadlocal_val !== Symbol("") && push!(q.args, threadlocal_init)
+  # reduction stuff
+  reduction_ops = Expr(:tuple)
+  reduction_vars = Expr(:tuple)
+  reduction_inits = Expr(:tuple)
+  reduction_set = Expr(:block)
+  for i in eachindex(reduction_var)
+    op = getfield(Polyester, reduction_op[i])
+    var = esc(reduction_var[i])
+    init = :(Polyester.initializer($op, $var))
+    push!(reduction_ops.args, op)
+    push!(reduction_vars.args, var)
+    push!(reduction_inits.args, init)
+    push!(reduction_set.args, :($var = $op($var, reduction_final[$i])))
+  end
+  reduction_init =
+    reduction_var === Tuple{}() ? donothing :
+    :($reduction_var_gen = var"##REDUCTION##INIT##")
+  if reduction_var !== Tuple{}()
+    push!(return_quote.args, reduction_var_gen)
+  else
+    push!(return_quote.args, nothing)
+  end
+
+  args = Expr(:tuple, Symbol("##LOOPOFFSET##"), Symbol("##LOOP_STEP##"))
+  closure_args = Expr(:tuple, args, :(var"##SUBSTART##"::Int), :(var"##SUBSTOP##"::Int))
+  if threadlocal_val !== Symbol("") || stride
+    push!(closure_args.args, :(var"##THREAD##"::Int))
+  end
+  reduction_var !== Tuple{}() && push!(closure_args.args, Symbol("##REDUCTION##INIT##"))
   if stride
     # we are to do length(var"##SUBSTART##":var"##SUBSTOP##") iterations
-    #
     loop_start_expr =
       :(var"##THREAD##" * var"##LOOP_STEP##" + var"##LOOPOFFSET##" - var"##LOOP_STEP##")
     loop_stop_expr = :($loopstart + (var"##SUBSTOP##" - var"##SUBSTART##") * var"##STEP##")
@@ -394,21 +432,24 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
         local $loop_stop = $loop_stop_expr
         # $(stride ? :(@show $loopstart, $loop_stop) : nothing)
         $threadlocal_get
+        $reduction_init
         @inbounds begin
           $excomb
         end
         $threadlocal_set
-        nothing
+        $return_quote
       end
     end
   end
   push!(q.args, esc(closureq))
-  batchcall = if threadlocal !== Symbol("") || stride
+  batchcall = if threadlocal_val !== Symbol("") || stride
     Expr(
       :call,
       batch,
       esc(closure),
       Val(true),
+      reduction_ops,
+      reduction_inits,
       threadtup,
       Symbol("##LOOPOFFSET##"),
       Symbol("##LOOP_STEP##"),
@@ -419,6 +460,8 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
       batch,
       esc(closure),
       Val(false),
+      reduction_ops,
+      reduction_inits,
       threadtup,
       Symbol("##LOOPOFFSET##"),
       Symbol("##LOOP_STEP##"),
@@ -427,6 +470,10 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
   for a ∈ arguments
     push!(args.args, get(defined, a, a))
     push!(batchcall.args, esc(a))
+  end
+  if threadlocal_val !== Symbol("")
+    push!(args.args, threadlocal_accum)
+    push!(batchcall.args, esc(threadlocal_accum))
   end
   push!(q.args, batchcall)
   quote
@@ -441,16 +488,18 @@ function enclose(exorig::Expr, minbatchsize, per::Symbol, threadlocal_tuple, str
       single_thread_result = begin
         $(esc(threadlocal_init_single)) # Initialize threadlocal storage
         $(esc(q_single))
-        $(esc(threadlocal_repack_single))
+        $(esc(threadlocal_return_single))
       end
-      # Put the single-thread threadlocal storage in a single-element Vector
-      $threadlocal_single_store
+      $threadlocal_vect_single
     else
-      $(esc(threadlocal_init1))
-      let
-        $q
+      multi_thread_result = let
+        reduction_final = $q
+        $reduction_set
+        $(esc(threadlocal_return))
       end
+      $threadlocal_vect
     end
+    nothing
   end
 end
 
@@ -461,16 +510,26 @@ Evaluate the loop on multiple threads.
 
     @batch minbatch=N for i in Iter; ...; end
 
-Create a thread-local storage used in the loop.
+Evaluate at least N iterations per thread. Will use at most `length(Iter) ÷ N` threads.
 
     @batch threadlocal=init() for i in Iter; ...; end
+
+Create a thread-local storage used in the loop.
 
 The `init` function will be called at the start at each thread. `threadlocal` will
 refer to storage local for the thread. At the end of the loop, a `threadlocal`
 vector containing all the thread-local values will be available. A type can be specified
 with `threadlocal=init()::Type`.
 
-Evaluate at least N iterations per thread. Will use at most `length(Iter) ÷ N` threads.
+    @batch reduction=((op1, var1), (op2, var2), ...) for i in Iter; ...; end
+
+Perform OpenMP-esque reduction on the `isbits` variables `var1`, `var2`, `...` using the
+operations `op1`, `op2`, `...` . The variables have to be initialized before the loop and
+cannot be a fieldname like `x.y` or `x[i]`.
+Supported operations are `+`, `*`, `min`, `max`, `&`, and `|`. The type does not have
+to be provided, since it is already inferred from the initialized variables.
+While `threadlocal` can do the same thing, `reduction` does not incur additional allocations
+and is generally more efficient for its purpose.
 
     @batch per=core for i in Iter; ...; end
     @batch per=thread for i in Iter; ...; end
@@ -499,14 +558,17 @@ You can pass both `per=(core/thread)` and `minbatch=N` options at the same time,
 
     @batch stride=true for i in Iter; ...; end
 
-This may be better for load balancing if iterations close to each other take a similar amount of time, but iterations far apart take different lengths of time. Setting this also forces `per=thread`. The default is `stride=false`.
+This may be better for load balancing if iterations close to each other take a similar
+amount of time, but iterations far apart take different lengths of time. Setting this also
+forces `per=thread`. The default is `stride=false`.
 """
 macro batch(ex)
   enclose(
     macroexpand(__module__, ex),
     1,
     :unspecified,
-    (Symbol(""), :Any),
+    (Symbol(""), :Any), # threadlocal: var, type
+    (Tuple{}(), Tuple{}()), # reduction: ops, vars
     false,
     __module__,
   )
@@ -515,20 +577,35 @@ function interpret_kwarg(
   arg,
   minbatch = 1,
   per = :unspecified,
-  threadlocal = (Symbol(""), :Any),
+  threadlocal = (Symbol(""), :Any), # var, type
+  reduction = (Tuple{}(), Tuple{}()), # ops, vars
   stride = false,
 )
   a = arg.args[1]
   v = arg.args[2]
-  if a === :reserve
-    @warn "reserve has been deprecated"
-    @assert v ≥ 0
-    reserve_per = v
-  elseif a === :minbatch
+  if a === :minbatch
     minbatch = v
   elseif a === :per
     per = v::Symbol
     @assert (per === :core) | (per === :thread)
+  elseif a === :reduction
+    @assert Meta.isexpr(v, :tuple) && v.head == :tuple
+    if Meta.isexpr(v.args[1], :tuple, 2)
+      for red in v.args
+        @assert Meta.isexpr(red, :tuple, 2) && red.head == :tuple
+      end
+      reducops = ntuple(length(v.args)) do i
+        v.args[i].args[1]
+      end
+      @assert SUPPORTED_REDUCE_OPS ⊇ reducops "Unsupported reduction operation."
+      reducvars = ntuple(length(v.args)) do i
+        v.args[i].args[2]
+      end
+      @assert allunique(reducvars)
+      reduction = (reducops, reducvars)
+    else
+      reduction = ((v.args[1],), (v.args[2],))
+    end
   elseif a === :threadlocal
     if Meta.isexpr(v, :(::), 2) && v.head == :(::)
       threadlocal = (v.args[1], v.args[2])
@@ -540,37 +617,90 @@ function interpret_kwarg(
   else
     throw(ArgumentError("kwarg $(a) not recognized."))
   end
-  minbatch, per, threadlocal, stride
+  minbatch, per, threadlocal, reduction, stride
 end
 macro batch(arg1, ex)
-  minbatch, per, threadlocal, stride = interpret_kwarg(arg1)
+  minbatch, per, threadlocal, reduction, stride = interpret_kwarg(arg1)
   per = per === :unspecified ? (stride ? :thread : :core) : per
-  enclose(macroexpand(__module__, ex), minbatch, per, threadlocal, stride, __module__)
+  enclose(
+    macroexpand(__module__, ex),
+    minbatch,
+    per,
+    threadlocal,
+    reduction,
+    stride,
+    __module__
+  )
 end
 macro batch(arg1, arg2, ex)
-  minbatch, per, threadlocal, stride = interpret_kwarg(arg1)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg2, minbatch, per, threadlocal, stride)
+  minbatch, per, threadlocal, reduction, stride = interpret_kwarg(arg1)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg2, minbatch, per, threadlocal, reduction, stride)
   per = per === :unspecified ? (stride ? :thread : :core) : per
-  enclose(macroexpand(__module__, ex), minbatch, per, threadlocal, stride, __module__)
+  enclose(
+    macroexpand(__module__, ex),
+    minbatch,
+    per,
+    threadlocal,
+    reduction,
+    stride,
+    __module__
+  )
 end
 macro batch(arg1, arg2, arg3, ex)
-  minbatch, per, threadlocal, stride = interpret_kwarg(arg1)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg2, minbatch, per, threadlocal, stride)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg3, minbatch, per, threadlocal, stride)
+  minbatch, per, threadlocal, reduction, stride = interpret_kwarg(arg1)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg2, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg3, minbatch, per, threadlocal, reduction, stride)
   per = per === :unspecified ? (stride ? :thread : :core) : per
-  enclose(macroexpand(__module__, ex), minbatch, per, threadlocal, stride, __module__)
+  enclose(
+    macroexpand(__module__, ex),
+    minbatch,
+    per,
+    threadlocal,
+    reduction,
+    stride,
+    __module__
+  )
 end
 macro batch(arg1, arg2, arg3, arg4, ex)
-  minbatch, per, threadlocal, stride = interpret_kwarg(arg1)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg2, minbatch, per, threadlocal, stride)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg3, minbatch, per, threadlocal, stride)
-  minbatch, per, threadlocal, stride =
-    interpret_kwarg(arg3, minbatch, per, threadlocal, stride)
+  minbatch, per, threadlocal, reduction, stride = interpret_kwarg(arg1)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg2, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg3, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg4, minbatch, per, threadlocal, reduction, stride)
   per = per === :unspecified ? (stride ? :thread : :core) : per
-  enclose(macroexpand(__module__, ex), minbatch, per, threadlocal, stride, __module__)
+  enclose(
+    macroexpand(__module__, ex),
+    minbatch,
+    per,
+    threadlocal,
+    reduction,
+    stride,
+    __module__
+  )
+end
+macro batch(arg1, arg2, arg3, arg4, arg5, ex)
+  minbatch, per, threadlocal, reduction, stride = interpret_kwarg(arg1)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg2, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg3, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg4, minbatch, per, threadlocal, reduction, stride)
+  minbatch, per, threadlocal, reduction, stride =
+    interpret_kwarg(arg5, minbatch, per, threadlocal, reduction, stride)
+  per = per === :unspecified ? (stride ? :thread : :core) : per
+  enclose(
+    macroexpand(__module__, ex),
+    minbatch,
+    per,
+    threadlocal,
+    reduction,
+    stride,
+    __module__
+  )
 end

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -373,7 +373,7 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
     :($(esc(threadlocal_var)) = multi_thread_result)
   threadlocal_get =
     threadlocal_val === Symbol("") ? donothing :
-    :($threadlocal_var_gen = $threadlocal_val::$threadlocal_type)
+    :($threadlocal_var_gen::$threadlocal_type = $threadlocal_val)
   threadlocal_set =
     threadlocal_val === Symbol("") ? donothing :
     :($threadlocal_accum[var"##THREAD##"] = $threadlocal_var_gen)

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -388,7 +388,7 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
   for i in eachindex(reduction_var)
     op = getfield(Polyester, reduction_op[i])
     var = esc(reduction_var[i])
-    init = :(Polyester.initializer($op, $var))
+    init = :(initializer($op, $var))
     push!(reduction_ops.args, op)
     push!(reduction_vars.args, var)
     push!(reduction_inits.args, init)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,7 +297,7 @@ Base.eachindex(e::Iterators.Enumerate{LazyTree{T}}) where {T} = eachindex(e.itr)
   evt = 5
 end
 
-@testset "local thread storate" begin
+@testset "threadlocal storage" begin
   local1 = let
     @batch threadlocal = 0 for i = 0:9
       threadlocal += 1
@@ -374,6 +374,116 @@ end
   allocated(f::F) where {F} = @allocated f()
   allocated(f)
   @test allocated(f) < 300 + 40 * Threads.nthreads()
+end
+
+@testset "reduction" begin
+  local1 = let
+    red = 0
+    @batch reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  local2 = let
+    red = 0
+    @batch minbatch = 5 reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  local3 = let
+    red = 0
+    @batch per = core reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  local4 = let
+    red = 0
+    @batch per = core minbatch = 100 reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  local5 = let
+    red = 0
+    @batch minbatch = 100 stride = true reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  myinitA() = 0
+  local6 = let
+    red = myinitA()
+    @batch reduction = (+, red) for i = 0:9
+      red += 1
+    end
+    red
+  end
+  local7, local8 = let
+    red = 0
+    @batch minbatch = 100 stride = true reduction = (+,red) threadlocal = red for i = 0:9
+      red += 1
+      threadlocal += 1
+    end
+    red, threadlocal[1]
+  end
+  @test local1 == local2 == local3 == local4 == local5 == local6 == local7 == local8
+  # check different operations
+  local9 = let
+    red = 1.0
+    @batch reduction = (*,red) for i = 1:100
+      red *= 4i^2 / (4i^2 - 1)
+    end
+    2red
+  end
+  @test local9 ≈ 2prod(4i^2 / (4i^2 - 1) for i = 1:100)
+  # multiple reductions
+  local10, local11, local12 = let
+    red1 = 0
+    red2 = 0
+    red3 = 0
+    @batch reduction = ((+,red1), (+,red2), (+,red3)) for i = 0:9
+      red1 += 1
+      red2 += 1
+      red3 -= 1
+    end
+    red1, red2, red3
+  end
+  @test local10 == local11 == -local12
+  # # check that each thread has a separate init
+  # myvar = 0
+  # myinitC() = myvar += 1
+  # inits = let
+  #   threadlocal = myinitC()
+  #   @batch reduction = (+,threadlocal) for i = 0:9
+  #     threadlocal += 1
+  #   end
+  #   threadlocal
+  # end
+  # @test length(inits) == 1 || inits[1] != inits[end] # this test has a race condition and can (rarely) fail
+  # check that types are respected
+  myinitD() = Float16(1.0)
+  settingtype = let
+    threadlocal = myinitD()
+    @batch reduction = (+,threadlocal) for i = 0:9
+      threadlocal += 1
+    end
+    threadlocal
+  end
+  @test eltype(settingtype) == Float16
+  # check for excessive allocations
+  function f()
+    n = 1000
+    threadlocal = 1.0
+    @batch minbatch = 10 reduction = (+,threadlocal) for i = 1:n
+      threadlocal += 1.0 / threadlocal
+    end
+    return threadlocal
+  end
+  allocated(f::F) where {F} = @allocated f()
+  allocated(f)
+  @test allocated(f) == 0
 end
 
 @testset "locks and refvalues" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -451,28 +451,7 @@ end
     red1, red2, red3
   end
   @test local10 == local11 == -local12
-  # # check that each thread has a separate init
-  # myvar = 0
-  # myinitC() = myvar += 1
-  # inits = let
-  #   threadlocal = myinitC()
-  #   @batch reduction = (+,threadlocal) for i = 0:9
-  #     threadlocal += 1
-  #   end
-  #   threadlocal
-  # end
-  # @test length(inits) == 1 || inits[1] != inits[end] # this test has a race condition and can (rarely) fail
-  # check that types are respected
-  myinitD() = Float16(1.0)
-  settingtype = let
-    threadlocal = myinitD()
-    @batch reduction = (+,threadlocal) for i = 0:9
-      threadlocal += 1
-    end
-    threadlocal
-  end
-  @test eltype(settingtype) == Float16
-  # check for excessive allocations
+  # check for name interference with threadlocal (used to error on single threaded runs)
   function f()
     n = 1000
     threadlocal = 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -706,5 +706,5 @@ end
 
 if VERSION ≥ v"1.6"
   println("Package tests complete. Running `Aqua` checks.")
-  Aqua.test_all(Polyester)
+  Aqua.test_all(Polyester; deps_compat = (check_extras=false,))
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaSIMD/Polyester.jl/issues/112 by passing the threadlocal accumulator as an argument to the batchcall instead of capturing it.

I found that adding a more restrictive, OpenMP-like `reduction` flag was more elegant than checking whether `threadlocal` was `isbits` to eliminate allocations in such cases. Using this looks like:

```julia
red1 = 0
red2 = 0
red3 = 0
@batch reduction = ((+,red1), (+,red2), (+,red3)) for i = 0:9
  red1 += 1
  red2 += 1
  red3 -= 1
end
red1, red2, red3
```

It works by allocating the initial value (neutral element of the operation) within each threads function and loading + reducing them at the end. This PR also includes the `tid` fix from https://github.com/JuliaSIMD/Polyester.jl/pull/131/commits/faab451e419553294ccab1562eafa519c90ab256, fixes in the documentation and additional tests for the `reduction` functionality.