### PR TITLE
Fix poor performance when one of `batch`'s arguments is a `Type{...}`

### DIFF
--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -20,15 +20,13 @@ using PolyesterWeave:
   UnsignedIteratorEarlyStop,
   assume,
   disable_polyester_threads
-using CPUSummary: cache_linesize, num_cores, sys_threads
+using CPUSummary: num_cores
 
 export batch, @batch, disable_polyester_threads
 
 const SUPPORTED_REDUCE_OPS = (:+, :*, :min, :max, :&, :|)
 initializer(::typeof(+), ::T) where {T} = zero(T)
 initializer(::typeof(+), ::Bool) = zero(Int)
-initializer(::typeof(-), ::T) where {T} = zero(T)
-initializer(::typeof(-), ::Bool) = zero(Int)
 initializer(::typeof(*), ::T) where {T} = one(T)
 initializer(::typeof(min), ::T) where {T} = typemax(T)
 initializer(::typeof(max), ::T) where {T} = typemin(T)

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -316,21 +316,11 @@ end
   if nthread % Int32 ≤ zero(Int32)
     @label SERIAL
     if S
-      if C === 0
-        reducres = f!(args, one(Int), ulen % Int, 1)
-        return reducres
-      else
-        reducres = f!(args, one(Int), ulen % Int, 1, reducinits)
-        return reducres
-      end
+      reducres = f!(args, one(Int), ulen % Int, 1, reducinits)
+      return reducres
     else
-      if C === 0
-        reducres = f!(args, one(Int), ulen % Int)
-        return reducres
-      else
-        reducres = f!(args, one(Int), ulen % Int, reducinits)
-        return reducres
-      end
+      reducres = f!(args, one(Int), ulen % Int, reducinits)
+      return reducres
     end
   end
   nbatch = nthread + one(nthread)

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -223,15 +223,11 @@ end
     end
   end
   ret_quote = Expr(:return)
-  if C === 0
-    push!(ret_quote.args, nothing)
-  else
-    redtup = Expr(:tuple)
-    for j in 1:C
-      push!(redtup.args, Symbol("RVAR_", j))
-    end
-    push!(ret_quote.args, redtup)
+  redtup = Expr(:tuple)
+  for j in 1:C
+    push!(redtup.args, Symbol("RVAR_", j))
   end
+  push!(ret_quote.args, redtup)
 
   block = quote
     start = zero(UInt)

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -528,8 +528,8 @@ Perform OpenMP-esque reduction on the `isbits` variables `var1`, `var2`, `...` u
 operations `op1`, `op2`, `...` . The variables have to be initialized before the loop and
 cannot be a fieldname like `x.y` or `x[i]`.
 Supported operations are `+`, `*`, `min`, `max`, `&`, and `|`. The type does not have
-to be provided, since it is already inferred from the initialized variables---caution has
-to be taken to ensure that the type remains consistent throughout the loop.
+to be provided, since it is already inferred from the initialized variables---**caution has
+to be taken to ensure that the type remains consistent throughout the loop**.
 While `threadlocal` can do the same thing, `reduction` does not incur additional allocations
 and is generally more efficient for its purpose. It is up to the user to ensure that there
 are no data dependencies between iterations, which could lead to incorrect results.

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -207,6 +207,13 @@ Base.@propagate_inbounds combine(x::AbstractArray, I, j) =
   x[combine(CombineIndices(), I, j)]
 Base.@propagate_inbounds combine(x::AbstractArray, ::NoLoop, j) = x[j]
 
+struct WrapType{T} end
+wrap_type(@nospecialize(x)) = x
+wrap_type(::Type{T}) where {T} = WrapType{T}()
+
+unwrap_type(@nospecialize(x)) = x
+unwrap_type(::WrapType{T}) where {T} = T
+
 function makestatic!(expr)
   expr isa Expr || return expr
   for i in eachindex(expr.args)
@@ -421,9 +428,11 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
     loop_stop_expr =
       :(var"##SUBSTOP##" * var"##LOOP_STEP##" + var"##LOOPOFFSET##" - var"##LOOP_STEP##")
   end
+  unwrap_args = Expr(:block)
   closureq = quote
     $closure = let
       @inline $closure_args -> begin
+        $unwrap_args
         local var"##STEP##" = $(
           stride ?
           :($loop_step * min(Threads.nthreads()::Int, Sys.CPU_THREADS::Int)) :
@@ -470,11 +479,14 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
   end
   for a ∈ arguments
     push!(args.args, get(defined, a, a))
-    push!(batchcall.args, esc(a))
+    push!(batchcall.args, :(wrap_type($(esc(a)))))
   end
   if threadlocal_val !== Symbol("")
     push!(args.args, threadlocal_accum)
     push!(batchcall.args, esc(threadlocal_accum))
+  end
+  for a in args.args
+    push!(unwrap_args.args, :($a = $unwrap_type($a)))
   end
   push!(q.args, batchcall)
   quote

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -479,7 +479,7 @@ function enclose(exorig::Expr, minbatchsize, per, threadlocal, reduction, stride
   end
   for a ∈ arguments
     push!(args.args, get(defined, a, a))
-    push!(batchcall.args, :(wrap_type($(esc(a)))))
+    push!(batchcall.args, :($wrap_type($(esc(a)))))
   end
   if threadlocal_val !== Symbol("")
     push!(args.args, threadlocal_accum)


### PR DESCRIPTION
This PR is a fix for https://github.com/JuliaSIMD/Polyester.jl/issues/116 by wrapping each argument of `batch` in a `wrap_type` function and using `unwrap_type` before the start of the loop body, as @chriselrod suggested. A test is included in runtests.jl.

Also made it such that `batch` always returns an empty `Tuple` when `reduction` is not used, since it used to be a `Union{Nothing, Tuple{}}`.