### PR TITLE
Avoid throwing exceptions in `reset_threads!`

### DIFF
--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -44,7 +44,7 @@ Resets the threads used by [Polyester.jl](https://github.com/JuliaSIMD/Polyester
 """
 function reset_threads!()
   PolyesterWeave.reset_workers!()
-  foreach(ThreadingUtilities.checktask, eachindex(ThreadingUtilities.TASKS))
+  foreach(ThreadingUtilities.initialize_task, eachindex(ThreadingUtilities.TASKS))
   return nothing
 end
 end


### PR DESCRIPTION
With https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/54, I get the same exception multiple times when I call `Polyester.reset_threads!` afterward:
```julia
julia> Polyester.reset_threads!()
ERROR: TaskFailedException
Stacktrace:
 [1] checktask(tid::Int64)
   @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:74
 [2] foreach
   @ ./abstractarray.jl:3187 [inlined]
 [3] reset_threads!()
   @ Polyester ~/.julia/packages/Polyester/eqrC9/src/Polyester.jl:47
 [4] top-level scope
   @ REPL[26]:1

    nested task error: some error
    Stacktrace:
     [1] error(s::String)
       @ Base ./error.jl:35
     [2] macro expansion
       @ ./REPL[25]:4 [inlined]
     [3] #56
       @ ~/.julia/packages/Polyester/eqrC9/src/closure.jl:309 [inlined]
     [4] (::Polyester.BatchClosure{var"#56#57", ManualMemory.Reference{Tuple{…}}, false, Tuple{}})(p::Ptr{UInt64})
       @ Polyester ~/.julia/packages/Polyester/eqrC9/src/batch.jl:11
     [5] _call
       @ ~/.julia/packages/ThreadingUtilities/3z3g0/src/threadtasks.jl:11 [inlined]
     [6] (::ThreadingUtilities.ThreadTask)()
       @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:29
Some type information was truncated. Use `show(err)` to see complete types.

julia> Polyester.reset_threads!()
ERROR: TaskFailedException
Stacktrace:
 [1] checktask(tid::Int64)
   @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:74
 [2] foreach
   @ ./abstractarray.jl:3187 [inlined]
 [3] reset_threads!()
   @ Polyester ~/.julia/packages/Polyester/eqrC9/src/Polyester.jl:47
 [4] top-level scope
   @ REPL[26]:1

    nested task error: some error
    Stacktrace:
     [1] error(s::String)
       @ Base ./error.jl:35
     [2] macro expansion
       @ ./REPL[25]:4 [inlined]
     [3] #56
       @ ~/.julia/packages/Polyester/eqrC9/src/closure.jl:309 [inlined]
     [4] (::Polyester.BatchClosure{var"#56#57", ManualMemory.Reference{Tuple{…}}, false, Tuple{}})(p::Ptr{UInt64})
       @ Polyester ~/.julia/packages/Polyester/eqrC9/src/batch.jl:11
     [5] _call
       @ ~/.julia/packages/ThreadingUtilities/3z3g0/src/threadtasks.jl:11 [inlined]
     [6] (::ThreadingUtilities.ThreadTask)()
       @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:29
Some type information was truncated. Use `show(err)` to see complete types.

julia> Polyester.reset_threads!()

julia> Polyester.reset_threads!()
```
This PR solves this problem.