### PR TITLE
Reset only failed tasks in `reset_threads!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ PolyesterWeave = "0.1.8, 0.2"
 Static = "0.7, 0.8, 1"
 StaticArrayInterface = "1"
 StrideArraysCore = "0.3.11, 0.4, 0.5"
-ThreadingUtilities = "0.5"
+ThreadingUtilities = "0.5.4"
 julia = "1.6"
 
 [extras]

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -44,12 +44,7 @@ Resets the threads used by [Polyester.jl](https://github.com/JuliaSIMD/Polyester
 """
 function reset_threads!()
   PolyesterWeave.reset_workers!()
-  foreach(eachindex(ThreadingUtilities.TASKS)) do tid
-    t = ThreadingUtilities.TASKS[tid]
-    if istaskfailed(t)
-      ThreadingUtilities.initialize_task(tid)
-    end
-  end
+  foreach(ThreadingUtilities.reinit_task, eachindex(ThreadingUtilities.TASKS))
   return nothing
 end
 end

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -44,7 +44,12 @@ Resets the threads used by [Polyester.jl](https://github.com/JuliaSIMD/Polyester
 """
 function reset_threads!()
   PolyesterWeave.reset_workers!()
-  foreach(ThreadingUtilities.initialize_task, eachindex(ThreadingUtilities.TASKS))
+  foreach(eachindex(ThreadingUtilities.TASKS)) do tid
+    t = ThreadingUtilities.TASKS[tid]
+    if istaskfailed(t)
+      ThreadingUtilities.initialize_task(tid)
+    end
+  end
   return nothing
 end
 end


### PR DESCRIPTION
Based on https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/58.
Closes https://github.com/JuliaSIMD/Polyester.jl/issues/159.

https://github.com/JuliaSIMD/Polyester.jl/pull/154 caused Trixi.jl CI to freeze sometimes.
I don't have a MWE for this, but the solution is to only re-initialize failed tasks.

To summarize the previous developments:
- `ThreadingUtilities.checktask` did not throw an error, which means that threads with errors just failed silently (https://github.com/JuliaSIMD/Polyester.jl/issues/153).
- https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/54 changed this behavior to throw an error.
- `Polyester.reset_threads!` also used `checktask`, which now throws errors, so #154 changed this to call `ThreadingUtilities.initialize_task` instead of `checktask`. However, this initializes all tasks, not just the failed ones like before all of these PRs. Apparently, this can cause freezing.
- https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/58 adds `reinit_task`, which is the same as the old `checktask` and this PR uses this in `reset_threads!`.