### PR TITLE
Fix implicit imports and require Julia >= 1.10

### DIFF
--- a/.github/workflows/CI-julia-nightly.yml
+++ b/.github/workflows/CI-julia-nightly.yml
@@ -25,16 +25,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
         os:
           - ubuntu-latest
@@ -31,16 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "Polyester"
 uuid = "f517fe37-dbe3-4b94-8317-1923a5111588"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.7.18"
+version = "0.7.19"
 
 [deps]
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
@@ -16,9 +15,9 @@ StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 
 [compat]
-ArrayInterface = "7"
 BitTwiddlingConvenienceFunctions = "0.1"
 CPUSummary = "0.1.2 - 0.1.8, 0.1.11, 0.2.1"
+ExplicitImports = "1.13.2"
 IfElse = "0.1"
 ManualMemory = "0.1.3"
 PolyesterWeave = "0.1.8, 0.2"
@@ -26,12 +25,13 @@ Static = "0.7, 0.8, 1"
 StaticArrayInterface = "1"
 StrideArraysCore = "0.3.11, 0.4, 0.5"
 ThreadingUtilities = "0.5.4"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ForwardDiff", "Test"]
+test = ["Aqua", "ExplicitImports", "ForwardDiff", "Test"]

--- a/src/Polyester.jl
+++ b/src/Polyester.jl
@@ -3,14 +3,12 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_m
   @eval Base.Experimental.@max_methods 1
 end
 
-using ThreadingUtilities
-import StaticArrayInterface
-const ArrayInterface = StaticArrayInterface
+using ThreadingUtilities: ThreadingUtilities
 using Base.Cartesian: @nexprs
-using StaticArrayInterface: static_length, static_step, static_first, static_size
+using StaticArrayInterface: StaticArrayInterface, static_length, static_step, static_first
 using StrideArraysCore: object_and_preserve
-using ManualMemory: Reference
-using Static
+using ManualMemory: ManualMemory, Reference
+using Static: StaticInt, static
 using PolyesterWeave:
   PolyesterWeave,
   request_threads,

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -4,23 +4,23 @@ struct BatchClosure{F,A,S,C}
   f::F
 end
 function (b::BatchClosure{F,A,S,C})(p::Ptr{UInt}) where {F,A,S,C}
-  (offset, args) = ThreadingUtilities.load(p, A, 2 * sizeof(UInt))
-  (offset, start) = ThreadingUtilities.load(p, UInt, offset)
-  (offset, stop) = ThreadingUtilities.load(p, UInt, offset)
+  (offset, args) = ManualMemory.load(p, A, 2 * sizeof(UInt))
+  (offset, start) = ManualMemory.load(p, UInt, offset)
+  (offset, stop) = ManualMemory.load(p, UInt, offset)
   if C === Tuple{} && !S
     b.f(args, (start + one(UInt)) % Int, stop % Int)
   elseif C === Tuple{} && S
-    ((offset, i) = ThreadingUtilities.load(p, UInt, offset))
+    ((offset, i) = ManualMemory.load(p, UInt, offset))
     b.f(args, (start + one(UInt)) % Int, stop % Int, i % Int)
   elseif C !== Tuple{} && !S
-    ((offset, reducinits) = ThreadingUtilities.load(p, C, offset))
+    ((offset, reducinits) = ManualMemory.load(p, C, offset))
     reducres = b.f(args, (start + one(UInt)) % Int, stop % Int, reducinits)
-    ThreadingUtilities.store!(p, reducres, offset)
+    ManualMemory.store!(p, reducres, offset)
   else
-    ((offset, i) = ThreadingUtilities.load(p, UInt, offset))
-    ((offset, reducinits) = ThreadingUtilities.load(p, C, offset))
+    ((offset, i) = ManualMemory.load(p, UInt, offset))
+    ((offset, reducinits) = ManualMemory.load(p, C, offset))
     reducres = b.f(args, (start + one(UInt)) % Int, stop % Int, i % Int, reducinits)
-    ThreadingUtilities.store!(p, reducres, offset)
+    ManualMemory.store!(p, reducres, offset)
   end
   ThreadingUtilities._atomic_store!(p, ThreadingUtilities.SPIN)
   nothing
@@ -45,15 +45,15 @@ end
 
 @inline function load_threadlocals(tid, argtup::A, ::Val{S}, reductup::C) where {A,S,C}
   p = ThreadingUtilities.taskpointer(tid)
-  (offset, _) = ThreadingUtilities.load(p, UInt, sizeof(UInt))
-  (offset, _) = ThreadingUtilities.load(p, A, offset)
-  (offset, _) = ThreadingUtilities.load(p, UInt, offset)
-  (offset, _) = ThreadingUtilities.load(p, UInt, offset)
+  (offset, _) = ManualMemory.load(p, UInt, sizeof(UInt))
+  (offset, _) = ManualMemory.load(p, A, offset)
+  (offset, _) = ManualMemory.load(p, UInt, offset)
+  (offset, _) = ManualMemory.load(p, UInt, offset)
   if S
-    (offset, _) = ThreadingUtilities.load(p, UInt, offset)
+    (offset, _) = ManualMemory.load(p, UInt, offset)
   end
-  (offset, _) = ThreadingUtilities.load(p, C, offset)
-  (offset, reducvals) = ThreadingUtilities.load(p, C, offset)
+  (offset, _) = ManualMemory.load(p, C, offset)
+  (offset, reducvals) = ManualMemory.load(p, C, offset)
   return reducvals
 end
 
@@ -64,10 +64,10 @@ end
   start::UInt,
   stop::UInt,
 )
-  offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
-  offset = ThreadingUtilities.store!(p, argtup, offset)
-  offset = ThreadingUtilities.store!(p, start, offset)
-  offset = ThreadingUtilities.store!(p, stop, offset)
+  offset = ManualMemory.store!(p, fptr, sizeof(UInt))
+  offset = ManualMemory.store!(p, argtup, offset)
+  offset = ManualMemory.store!(p, start, offset)
+  offset = ManualMemory.store!(p, stop, offset)
   nothing
 end
 @inline function setup_batch!(
@@ -78,11 +78,11 @@ end
   stop::UInt,
   i_or_reductup,
 )
-  offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
-  offset = ThreadingUtilities.store!(p, argtup, offset)
-  offset = ThreadingUtilities.store!(p, start, offset)
-  offset = ThreadingUtilities.store!(p, stop, offset)
-  offset = ThreadingUtilities.store!(p, i_or_reductup, offset)
+  offset = ManualMemory.store!(p, fptr, sizeof(UInt))
+  offset = ManualMemory.store!(p, argtup, offset)
+  offset = ManualMemory.store!(p, start, offset)
+  offset = ManualMemory.store!(p, stop, offset)
+  offset = ManualMemory.store!(p, i_or_reductup, offset)
   nothing
 end
 @inline function setup_batch!(
@@ -94,12 +94,12 @@ end
   i::UInt,
   reductup,
 )
-  offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
-  offset = ThreadingUtilities.store!(p, argtup, offset)
-  offset = ThreadingUtilities.store!(p, start, offset)
-  offset = ThreadingUtilities.store!(p, stop, offset)
-  offset = ThreadingUtilities.store!(p, i, offset)
-  offset = ThreadingUtilities.store!(p, reductup, offset)
+  offset = ManualMemory.store!(p, fptr, sizeof(UInt))
+  offset = ManualMemory.store!(p, argtup, offset)
+  offset = ManualMemory.store!(p, start, offset)
+  offset = ManualMemory.store!(p, stop, offset)
+  offset = ManualMemory.store!(p, i, offset)
+  offset = ManualMemory.store!(p, reductup, offset)
   nothing
 end
 @inline function launch_batched_thread!(cfunc, tid, argtup, start, stop)

--- a/src/closure.jl
+++ b/src/closure.jl
@@ -245,7 +245,7 @@ function makestatic!(expr)
       j = findfirst(==(ex), (:axes, :size, :length))
       if j !== nothing
         expr.args[i] =
-          GlobalRef(ArrayInterface, (:static_axes, :static_size, :static_length)[j])
+          GlobalRef(StaticArrayInterface, (:static_axes, :static_size, :static_length)[j])
       end
     elseif ex isa Expr
       makestatic!(ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 println(
   "Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...",
 )
-using Polyester, Aqua, ForwardDiff
+using Polyester, Aqua, ExplicitImports, ForwardDiff
 using PolyesterWeave: dynamic_thread_count # min(Sys.CPU_THREADS, Threads.nthreads())
 using Base.Threads: @threads
 using Test
@@ -784,7 +784,33 @@ let x = Vector{Float64}(undef, 2)
   @test x == fill(2.0, 2)
 end
 
-if VERSION ≥ v"1.6"
-  println("Package tests complete. Running `Aqua` checks.")
-  Aqua.test_all(Polyester; deps_compat = (check_extras = false,))
+println("Package tests complete. Running `Aqua` and `ExplicitImports` checks.")
+Aqua.test_all(Polyester; deps_compat = (check_extras = false,))
+
+@testset "ExplicitImports" begin
+  # No implicit imports (`using XY`)
+  @test ExplicitImports.check_no_implicit_imports(Polyester) === nothing
+
+  # All explicit imports (`using XY: Z`) are loaded via their owners
+  @test ExplicitImports.check_all_explicit_imports_via_owners(Polyester) === nothing
+
+  # No explicit imports (`using XY: Z`) of non-public names
+  @test_broken ExplicitImports.check_all_explicit_imports_are_public(Polyester) === nothing
+
+  # No explicit imports (`using XY: Z`) that are not used
+  @test ExplicitImports.check_no_stale_explicit_imports(
+    Polyester;
+    # This imported name is used in manual expression building
+    ignore = (:object_and_preserve,),
+  ) === nothing
+
+  # Nothing is accessed via modules other than its owner
+  @test ExplicitImports.check_all_qualified_accesses_via_owners(Polyester) === nothing
+
+  # No accesses of non-public names
+  @test_broken ExplicitImports.check_all_qualified_accesses_are_public(Polyester) ===
+               nothing
+
+  # No self-qualified accesses
+  @test ExplicitImports.check_no_self_qualified_accesses(Polyester) === nothing
 end


### PR DESCRIPTION
Addresses https://github.com/SciML/Static.jl/issues/144.

As ExplicitImports (also previous versions) only supports Julia > 1.7, I used the opportunity to update the Julia compat entry to 1.10.