### PR TITLE
Preserve argtup

### DIFF
--- a/src/batch.jl
+++ b/src/batch.jl
@@ -261,7 +261,8 @@ end
     free_threads!(torelease_tuple)
     $ret_quote
   end
-  gcpr = Expr(:gc_preserve, block, :cfunc)
+  # argtup can be a mutable memory allocation and `batch_closure` will not gurantuee preservation
+  gcpr = Expr(:gc_preserve, block, :cfunc, :argtup)
   argt = Expr(:tuple)
   for k ∈ 1:K
     add_var!(q, argt, gcpr, args[k], :args, :gcp, k)


### PR DESCRIPTION
On Julia 1.12, we are observing occasional GC faults in [Trixi](https://github.com/trixi-framework/Trixi.jl/issues/2766). 

An in-depth root-cause analysis is availalble here: https://github.com/trixi-framework/Trixi.jl/issues/2766#issuecomment-3868077009

Short explanation: Polyester is laundering object references through void pointers (the taskpointer),
if one is not exceptionally careful in manually preserving the objects, references can be easily dropped.

The Trixi example fails for me in about 30-50 tries (30s per run so about half an hour),
running multiple parallel reproducers for several hours I am unable to hit the failure again with this patch.

